### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Imports:
   magrittr,
   pacman,
   plotly,
+  reactable,
   readxl,
   rhandsontable,
   rstudioapi,


### PR DESCRIPTION
Added reactable to Imports. (zgtools installation threw error: there is no package called ‘reactable’)